### PR TITLE
pull in specific version of wcjs-prebuilt that works in electron

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
 runtime = electron
 disturl = https://atom.io/download/electron
-target = 1.7.9
+target = 1.4.3
 arch = x64

--- a/package.json
+++ b/package.json
@@ -32,13 +32,14 @@
     "fs-jetpack": "^0.10.2",
     "run-sequence": "^1.2.2",
     "typescript": "^2.2.1",
-    "wcjs-player": "^6.0.1"
+    "wcjs-player": "^6.0.1",
+    "wcjs-prebuilt": "^3.0.0"
   },
   "devDependencies": {
     "@types/electron": "^1.4.33",
     "@types/node": "^7.0.7",
     "chai": "^3.5.0",
-    "electron": "1.7.9",
+    "electron": "1.4.3",
     "electron-builder": "^8.6.0",
     "electron-mocha": "^3.0.0",
     "electron-rebuild": "^1.6.0",


### PR DESCRIPTION
Running up `master` shows this error:

<img width="809" src="https://user-images.githubusercontent.com/359239/31636986-6b8c4a68-b318-11e7-86d1-bbbdbb7259e5.png">

Fine, missing dependency, `npm install --save wcjs-prebuilt` let's do this...

<img width="741"  src="https://user-images.githubusercontent.com/359239/31637022-8d8793a2-b318-11e7-90e7-8ecefcb5496a.png">

Oh, oh dear. This is hella behind the current versions of electron - let's pin ourselves to 1.4.3 (because that's the version the installer wants to use, that's a whole other issue that we can't fix today)...

<img width="830" alt="screen shot 2017-10-17 at 8 55 56 am" src="https://user-images.githubusercontent.com/359239/31637143-0e50f672-b319-11e7-9f03-125bcf10cbc8.png">

Cool, no errors, seems to logging stuff in app.js now.

Hope this helps!


